### PR TITLE
add CI GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - name: Build and test with Rake
+      run: |
+        gem install bundler
+        bundle install --jobs 4 --retry 3
+        bundle exec rake

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # omniauth-dex-energy
 
+![CI](https://github.com/greensync/omniauth-dex-energy/workflows/CI/badge.svg)
+
 An OmniAuth strategy to authenticate with deX.
 
 ## Table of Contents


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for CI. It checks out the code then run tests through `rake`.