### PR TITLE
use https://who.dex.energy as the default site

### DIFF
--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -10,10 +10,7 @@ oauth2_client_secret = ENV['OAUTH2_CLIENT_SECRET']
 use Rack::Session::Cookie
 
 use OmniAuth::Builder do
-  provider :dex_energy, oauth2_client_id, oauth2_client_secret,
-           client_options: {
-             site: 'https://who.dex.energy',
-           }
+  provider :dex_energy, oauth2_client_id, oauth2_client_secret
 end
 
 get '/' do

--- a/lib/omniauth/strategies/dex_energy.rb
+++ b/lib/omniauth/strategies/dex_energy.rb
@@ -9,7 +9,6 @@ module OmniAuth
       option :name, 'dex_energy'
 
       option :client_options, site: 'https://who.dex.energy', auth_scheme: :basic_auth
-      # option :client_options, auth_scheme: :basic_auth
 
       uid do
         raw_info['sub']

--- a/lib/omniauth/strategies/dex_energy.rb
+++ b/lib/omniauth/strategies/dex_energy.rb
@@ -8,7 +8,8 @@ module OmniAuth
     class DexEnergy < OmniAuth::Strategies::OAuth2
       option :name, 'dex_energy'
 
-      option :client_options, auth_scheme: :basic_auth
+      option :client_options, site: 'https://who.dex.energy', auth_scheme: :basic_auth
+      # option :client_options, auth_scheme: :basic_auth
 
       uid do
         raw_info['sub']


### PR DESCRIPTION
This means that users of the gem don't need to specify the issuer URL;
all they need to bring is the client ID and client secret.

The consumer can still override the site with usage like this:

```ruby
use OmniAuth::Builder do
  provider :dex_energy, oauth2_client_id, oauth2_client_secret,
           client_options: {
             site: 'http://localhost:5100',
           }
end
```

Closes #2