### PR TITLE
implement gem publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # omniauth-dex-energy
 
 ![CI](https://github.com/greensync/omniauth-dex-energy/workflows/CI/badge.svg)
+[![Gem Version](https://badge.fury.io/rb/omniauth-dex-energy.png)](https://badge.fury.io/rb/omniauth-dex-energy)
 
 An OmniAuth strategy to authenticate with deX.
 
@@ -26,11 +27,15 @@ gem 'omniauth-dex-energy'
 
 And then execute:
 
-    $ bundle install
+```sh
+bundle install
+```
 
 Or install it yourself as:
 
-    $ gem install omniauth-dex-energy
+```sh
+gem install omniauth-dex-energy
+```
 
 ## Usage
 

--- a/bin/publish-gem
+++ b/bin/publish-gem
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+set -x
+
+version=$(cat $(dirname $0)/../VERSION)
+
+gem build omniauth-dex-energy
+gem push omniauth-dex-energy-${version}.gem

--- a/bin/publish-gem
+++ b/bin/publish-gem
@@ -4,5 +4,6 @@ set -Eeuo pipefail
 
 version=$(git describe --exact-match HEAD)
 
+git push origin ${version}
 gem build omniauth-dex-energy
 gem push omniauth-dex-energy-${version}.gem

--- a/bin/publish-gem
+++ b/bin/publish-gem
@@ -2,9 +2,7 @@
 
 set -Eeuo pipefail
 
-set -x
-
-version=$(cat $(dirname $0)/../VERSION)
+version=$(git describe --exact-match HEAD)
 
 gem build omniauth-dex-energy
 gem push omniauth-dex-energy-${version}.gem

--- a/omniauth-dex-energy.gemspec
+++ b/omniauth-dex-energy.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'omniauth-dex-energy'
-  spec.version       = '0.1.0'
+  spec.version       = File.read('VERSION').strip
   spec.authors       = ['Cera Davies', 'Nick Burgin', 'Mike Williams']
   spec.email         = [
     'internalplatform@greensync.com.au',

--- a/omniauth-dex-energy.gemspec
+++ b/omniauth-dex-energy.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'pry-byebug', '~> 3.8.0'
-  spec.add_development_dependency 'rack'
+  spec.add_development_dependency 'rack', '~> 1.6.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.77'

--- a/omniauth-dex-energy.gemspec
+++ b/omniauth-dex-energy.gemspec
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+gem_version = `git describe --exact-match HEAD`.strip
+
 Gem::Specification.new do |spec|
   spec.name          = 'omniauth-dex-energy'
-  spec.version       = File.read('VERSION').strip
+  spec.version       = gem_version
   spec.authors       = ['Cera Davies', 'Nick Burgin', 'Mike Williams']
   spec.email         = [
     'internalplatform@greensync.com.au',


### PR DESCRIPTION
This branch adds a script - `bin/publish-gem` - that publishes the gem based on a git tag. If the current commit is not tagged, the gem cannot be published.