### PR TITLE
Set the scope to 'openid' by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/.idea/

--- a/lib/omniauth/strategies/dex_energy.rb
+++ b/lib/omniauth/strategies/dex_energy.rb
@@ -10,6 +10,8 @@ module OmniAuth
 
       option :client_options, site: 'https://who.dex.energy', auth_scheme: :basic_auth
 
+      option :authorize_params, scope: 'openid'
+
       uid do
         raw_info['sub']
       end


### PR DESCRIPTION
As per the openid-connect spec, this scope is required, but the strategy wasn't adding it by default.
Tested with a local instance of greensync/who to make sure the parameter was in the request.

closed #10