### PR TITLE
implement a logout_uri helper

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,9 @@ RSpec/MultipleExpectations:
   Max: 4
 RSpec/NestedGroups:
   Max: 7
+RSpec/FilePath:
+  CustomTransform:
+    OmniAuth: omniauth
 Style/Documentation:
   Enabled: false
 Style/DoubleNegation:

--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -31,7 +31,14 @@ get '/auth/dex_energy/callback' do
 end
 
 get '/logout' do
-  # Log the user out of their session in the app - but not in the Identity Provider.
+  # Log the user out of their session in the app, and then redirect them to the IdP
+  # so that it can log them out.
+  # The user will be redirect back to us afterwards.
   session.delete(:user)
-  redirect request.referrer
+
+  logout_url = OmniAuth::Strategies::DexEnergy.logout_uri(
+    client_id: oauth2_client_id,
+    redirect_uri: to('/')
+  )
+  redirect logout_url
 end

--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -38,7 +38,7 @@ get '/logout' do
 
   logout_url = OmniAuth::Strategies::DexEnergy.logout_uri(
     client_id: oauth2_client_id,
-    redirect_uri: to('/')
+    redirect_uri: to('/'),
   )
   redirect logout_url
 end

--- a/lib/omniauth/strategies/dex_energy.rb
+++ b/lib/omniauth/strategies/dex_energy.rb
@@ -6,9 +6,11 @@ require 'omniauth-oauth2'
 module OmniAuth
   module Strategies
     class DexEnergy < OmniAuth::Strategies::OAuth2
+      DEFAULT_SITE = 'https://who.dex.energy'
+
       option :name, 'dex_energy'
 
-      option :client_options, site: 'https://who.dex.energy', auth_scheme: :basic_auth
+      option :client_options, site: DEFAULT_SITE, auth_scheme: :basic_auth
 
       option :authorize_params, scope: 'openid'
 
@@ -26,6 +28,16 @@ module OmniAuth
         {
           'raw_info' => raw_info,
         }
+      end
+
+      class << self
+        def logout_uri(client_id:, redirect_uri:, site: nil)
+          site ||= DEFAULT_SITE
+
+          encoded_redirect_uri = URI.encode_www_form_component(redirect_uri)
+
+          "#{site}/oauth/logout?client_id=#{client_id}&redirect_uri=#{encoded_redirect_uri}"
+        end
       end
 
       private

--- a/spec/omniauth/strategies/dex_energy_spec.rb
+++ b/spec/omniauth/strategies/dex_energy_spec.rb
@@ -1,0 +1,13 @@
+require 'omniauth/strategies/dex_energy'
+
+RSpec.describe OmniAuth::Strategies::DexEnergy do
+  describe '$logout_uri' do
+    let(:client_id) { 'abc-def' }
+    let(:redirect_uri) { 'https://example.com/hello?logged_out=true&refresh=no' }
+
+    it 'returns the appropriate URL' do
+      expected_logout_uri = 'https://who.dex.energy/oauth/logout?client_id=abc-def&redirect_uri=https%3A%2F%2Fexample.com%2Fhello%3Flogged_out%3Dtrue%26refresh%3Dno'
+      expect(described_class.logout_uri(client_id: client_id, redirect_uri: redirect_uri)).to eq(expected_logout_uri)
+    end
+  end
+end


### PR DESCRIPTION
This will help our client applications to generate the URI in the IdP to send users to when they are being logged out.

Contributes to greensync/who#17

Co-Authored-By: Nick Burgin <nick.burgin@greensync.com.au>

---

This is a draft while we confirm in some client applications that the behaviour is correct.